### PR TITLE
Switch demo to Gemini via LangChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](frontend/LICENSE)
 
-This monorepo demonstrates how you can use OpenAI's CUA model and [computer use tool](https://platform.openai.com/docs/guides/tools-computer-use) to automate frontend testing. It uses [Playwright](https://playwright.dev) to spin up a browser instance and navigate to the web app to be tested. The CUA model then follows the provided test case and executes actions on the interface until the test case is done.  
+This monorepo demonstrates how you can use Google's Gemini API to generate Playwright test scripts from natural language descriptions. The backend sends the user prompt to Gemini and returns executable Playwright code.
 
 The repo contains three applications that work together:
 
 - **frontend** – Next.js web interface used to configure tests and watch them run.
-- **cua-server** – Node service that communicates with the OpenAI CUA model and drives Playwright to interact in a browser with the sample app.
+- **gemini-server** – Node service that sends the instructions to Gemini and returns Playwright code.
 - **sample-test-app** – Example e‑commerce site used as an example app to test by the agent.
 
 ![screenshot](./screenshot.jpg)
@@ -26,11 +26,11 @@ The repo contains three applications that work together:
 
 2. **Prepare environment files**
 
-   If you haven't set your `OPENAI_API_KEY` environment variable on your terminal or globally on your machine (set up instructions [here](https://platform.openai.com/docs/libraries#create-and-export-an-api-key)), edit each `.env.development` file and set `OPENAI_API_KEY`.
+   Edit each `.env.development` file and set `GOOGLE_API_KEY` with your Gemini credentials.
 
    ```bash
    cp frontend/.env.example frontend/.env.development
-   cp cua-server/.env.example cua-server/.env.development
+   cp gemini-server/.env.example gemini-server/.env.development
    cp sample-test-app/.env.example sample-test-app/.env.development
    ```
 
@@ -60,21 +60,21 @@ The repo contains three applications that work together:
 
    - Frontend UI: http://localhost:3000
    - Sample app: http://localhost:3005
-   - CUA server: [ws://localhost:8080](http://localhost:8080)
+   - Gemini server: [ws://localhost:8000](http://localhost:8000)
 
    Navigate to [localhost:3000](http://localhost:3000) to see the frontend UI and run the demo.
 
 For details on each app see their READMEs:
 
 - [frontend/README.md](frontend/README.md)
-- [cua-server/README.md](cua-server/README.md)
+- [gemini-server/README.md](gemini-server/README.md)
 - [sample-test-app/README.md](sample-test-app/README.md)
 
 ## Customization
 
 You can use this testing agent with any web app you choose, and update the test case and target URL either in the config UI or in the `frontend/lib/constants.ts` file (default values used in the UI).
 
-`sample-test-app` is only provided as an example to try the demo, and `frontend` as a testing interface. The core logic of the testing agent is in `cua-server`, which is what you might want to bring into your own application.
+`sample-test-app` is only provided as an example to try the demo, and `frontend` as a testing interface. The core logic of the testing agent is in `gemini-server`, which is what you might want to bring into your own application.
 
 ## Contributing
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,5 @@
-OPENAI_API_KEY=your-openai-key
+# URL for the Gemini WebSocket server
+NEXT_PUBLIC_SOCKET_SERVER_URL=http://localhost:8000
 # Optional: Set the display size for the browser.
 DISPLAY_WIDTH=1024
 DISPLAY_HEIGHT=768

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,11 +2,11 @@
 
 ![NextJS](https://img.shields.io/badge/Built_with-NextJS-blue)
 
-This Next.js application provides the web interface for the Testing Agent demo. It allows you to define test cases, sends them to the CUA server and displays messages from the CUA model in the UI.
+This Next.js application provides the web interface for the Testing Agent demo. It allows you to define test cases, sends them to the Gemini server and displays the generated Playwright code in the UI.
 
 ## Setup
 
-1. Copy the example environment file and add your OpenAI key:
+1. Copy the example environment file and add your Gemini key:
    ```bash
    cp .env.example .env.development
    # edit .env.development
@@ -18,4 +18,4 @@ This Next.js application provides the web interface for the Testing Agent demo. 
    ```
    The app will be running at [http://localhost:3000](http://localhost:3000).
 
-Make sure the CUA server is running (see [cua-server/README.md](../cua-server/README.md)) and, for demo purposes, the sample app ([sample-test-app/README.md](../sample-test-app/README.md)).
+Make sure the Gemini server is running (see [gemini-server/README.md](../gemini-server/README.md)) and, for demo purposes, the sample app ([sample-test-app/README.md](../sample-test-app/README.md)).

--- a/gemini-server/.env.example
+++ b/gemini-server/.env.example
@@ -1,0 +1,2 @@
+GOOGLE_API_KEY=your-gemini-key
+PORT=8000

--- a/gemini-server/README.md
+++ b/gemini-server/README.md
@@ -1,0 +1,23 @@
+# Gemini Server
+
+This simple Express service connects to the Gemini API via LangChain and exposes a Socket.IO WebSocket API used by the frontend.
+
+## Setup
+
+1. Copy the example environment file and add your Gemini key:
+   ```bash
+   cp .env.example .env.development
+   # edit .env.development
+   ```
+2. Install dependencies and launch the server:
+   ```bash
+   npm install
+   npm run dev
+   ```
+   The server listens on port `8000` by default. Set `PORT` to change it.
+
+### Environment Variables
+
+- `GOOGLE_API_KEY` – required for calls to Gemini.
+- `PORT` (optional) – WebSocket port (default `8000`).
+- `CORS_ORIGIN` (optional) – allowed CORS origin for incoming connections.

--- a/gemini-server/index.js
+++ b/gemini-server/index.js
@@ -1,0 +1,52 @@
+import express from 'express';
+import http from 'http';
+import { Server as SocketIOServer } from 'socket.io';
+import dotenv from 'dotenv';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
+
+dotenv.config({ path: '.env.development' });
+
+const PORT = process.env.PORT || 8000;
+const CORS_ORIGIN = process.env.CORS_ORIGIN || '*';
+
+const app = express();
+const httpServer = http.createServer(app);
+const io = new SocketIOServer(httpServer, { cors: { origin: CORS_ORIGIN } });
+
+const model = new ChatGoogleGenerativeAI({
+  model: 'gemini-pro',
+  apiKey: process.env.GOOGLE_API_KEY,
+});
+
+app.get('/', (req, res) => {
+  res.send('Gemini server running');
+});
+
+io.on('connection', (socket) => {
+  console.log('Client connected', socket.id);
+
+  socket.on('testCaseInitiated', async (data) => {
+    const prompt = `You are a QA automation assistant. Generate a Playwright test in TypeScript that follows these instructions:\n${data.testCase}\nReturn only the code inside a markdown code block.`;
+    try {
+      const response = await model.invoke(prompt);
+      socket.emit('message', response.content);
+    } catch (err) {
+      console.error('Gemini error', err);
+      socket.emit('message', 'Error generating test code.');
+    }
+  });
+
+  socket.on('message', async (msg) => {
+    try {
+      const response = await model.invoke(msg);
+      socket.emit('message', response.content);
+    } catch (err) {
+      console.error('Gemini error', err);
+      socket.emit('message', 'Error generating response.');
+    }
+  });
+});
+
+httpServer.listen(PORT, () => {
+  console.log(`Socket server listening on port ${PORT}`);
+});

--- a/gemini-server/package.json
+++ b/gemini-server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "gemini-server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "socket.io": "^4.8.1",
+    "dotenv": "^16.5.0",
+    "@langchain/google-genai": "^0.0.13"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,25 +8,18 @@
       "workspaces": [
         "sample-test-app",
         "frontend",
-        "cua-server"
+        "gemini-server"
       ],
       "devDependencies": {
         "concurrently": "^8.2.2"
       }
     },
-    "cua-server": {
+    "gemini-server": {
       "dependencies": {
-        "openai": "^4.87.3",
-        "pino": "^9.6.0",
-        "pino-pretty": "^13.0.0",
-        "playwright": "^1.52.0",
-        "socket.io": "^4.8.1",
-        "uuid": "^11.1.0"
-      },
-      "devDependencies": {
-        "@types/node": "^20",
-        "ts-node-dev": "^2.0.0",
-        "typescript": "^5"
+        "@langchain/google-genai": "^0.0.13",
+        "dotenv": "^16.5.0",
+        "express": "^4.19.2",
+        "socket.io": "^4.8.1"
       }
     },
     "frontend": {
@@ -3804,8 +3797,8 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
-    "node_modules/cua-server": {
-      "resolved": "cua-server",
+    "node_modules/gemini-server": {
+      "resolved": "gemini-server",
       "link": true
     },
     "node_modules/d3-array": {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "workspaces": [
     "sample-test-app",
     "frontend",
-    "cua-server"
+    "gemini-server"
   ],
   "scripts": {
     "dev:sample-test-app": "npm run dev --prefix sample-test-app",
     "dev:frontend": "npm run dev --prefix frontend",
-    "dev:cua-server": "npm run dev --prefix cua-server",
-    "dev": "concurrently \"npm:dev:sample-test-app\" \"npm:dev:frontend\" \"npm:dev:cua-server\""
+    "dev:gemini-server": "npm run dev --prefix gemini-server",
+    "dev": "concurrently \"npm:dev:sample-test-app\" \"npm:dev:frontend\" \"npm:dev:gemini-server\""
   },
   "devDependencies": {
     "concurrently": "^8.2.2"


### PR DESCRIPTION
## Summary
- replace references to OpenAI with Gemini
- add minimal `gemini-server` using Express and LangChain
- update workspaces and lock file
- document Gemini setup
- adjust frontend environment example

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68858b92c9508332916b81bef957ea2e